### PR TITLE
Add check for sRGB

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,20 +32,14 @@ Thanks to the authors of [SPOUT](https://github.com/leadedge/Spout2) for the lib
 - Run the installer (accepting installation from untrusted source)
 - Select the `OBS` directory if not the default install location
 
-### Manual Installation
-
-- If you are unable to run the installer, download the release zip file `OBS_SPOUT2_Plugin_Build_xxx.zip`
-- Extract the entire contents into your OBS directory
-- Verify that `win-spout.dll` is in the dir `<obs-install>\obs-plugins\64bit`
-
 ## Contributing / Building
 
 - Clone the [main OBS repository](https://github.com/obsproject/obs-studio)
-- Carefully follow their [build instructions](https://obsproject.com/wiki/install-instructions#windows-build-directions)
+- Carefully follow their [build instructions](https://obsproject.com/wiki/install-instructions#windows-build-directions) ensuring that your `build` folder is `build64`
 - Add this repo as a submodule inside the plugins folder: `git submodule add git@github.com:Off-World-Live/obs-spout2-source-plugin.git plugins/win-spout`
-- Download the latest [Spout Source](https://github.com/leadedge/Spout2/releases) and extract the contents of [this folder](https://github.com/leadedge/Spout2/tree/master/SpoutSDK/Source/SPOUT_LIBRARY) into a new folder `/deps/spout` inside the OBS Source code directory
-- So far I have only built this in 64bit but I see no reason why it should not work with 32bit builds.
-
+- Download the latest `Source.zip` from [the official SPOUT releases](https://github.com/leadedge/Spout2/releases) and extract the contents of [this folder](https://github.com/leadedge/Spout2/tree/master/SPOUTSDK/SpoutLibrary) into a new folder `/deps/spout` inside the OBS Source code directory
+- Edit the `CMakeLists.txt` file in `/plugins` directory and add `add_subdirectory(win-spout)` inside the `if(WIN32)` block.
+- Run `Configure`, `Generate` and then `Open Project` in the `CMake Gui`
 ### Building the windows installer
 
 - Download the latest version of [NSIS here](https://nsis.sourceforge.io/Download);

--- a/win-spout-installer.nsi
+++ b/win-spout-installer.nsi
@@ -2,7 +2,7 @@
 
 ; Define your application name
 !define APPNAME "Spout 2 OBS Plugin"
-!define APPVERSION "0.4"
+!define APPVERSION "0.5"
 !define APPNAMEANDVERSION "Spout 2 OBS Plugin ${APPVERSION}"
 
 ; Main Install settings

--- a/win-spout.cpp
+++ b/win-spout.cpp
@@ -14,7 +14,7 @@
 #include <sys/stat.h>
 #include <string.h>
 
-#include "Include/SpoutLibrary.h"
+#include "SpoutLibrary.h"
 #ifdef _WIN64
 #pragma comment(lib, "Binaries/x64/SpoutLibrary.lib")
 #else
@@ -153,7 +153,7 @@ static void win_spout_init(void *data, bool forced = false)
 	}
 
 	if (context->useFirstSender) {
-		if (context->spoutptr->GetSenderName(0, context->senderName)) {
+		if (context->spoutptr->GetSender(0, context->senderName)) {
 			if (!context->spoutptr->SetActiveSender(
 				    context->senderName)) {
 				if (context->spout_status != -4) {
@@ -176,7 +176,7 @@ static void win_spout_init(void *data, bool forced = false)
 		bool exists = false;
 		// then get the name of each sender from SPOUT
 		for (index = 0; index < totalSenders; index++) {
-			context->spoutptr->GetSenderName(index, senderName);
+			context->spoutptr->GetSender(index, senderName);
 			if (strcmp(senderName, context->senderName) == 0) {
 				exists = true;
 				break;
@@ -428,7 +428,7 @@ static void fill_senders(SPOUTHANDLE spoutptr, obs_property_t *list)
 	char senderName[256];
 	// then get the name of each sender from SPOUT
 	for (index = 0; index < totalSenders; index++) {
-		spoutptr->GetSenderName(index, senderName);
+		spoutptr->GetSender(index, senderName);
 		obs_property_list_add_string(list, senderName, senderName);
 	}
 }

--- a/win-spout.cpp
+++ b/win-spout.cpp
@@ -9,6 +9,7 @@
  */
 #include <obs-module.h>
 #include <graphics/image-file.h>
+#include <graphics/graphics.h>
 #include <util/platform.h>
 #include <util/dstr.h>
 #include <sys/stat.h>
@@ -407,7 +408,10 @@ static void win_spout_render(void *data, gs_effect_t *effect)
 	}
 
 	while (gs_effect_loop(effect, "Draw")) {
+		bool linearRGB = gs_get_linear_srgb();
+		gs_set_linear_srgb(false);
 		obs_source_draw(context->texture, 0, 0, 0, 0, false);
+		gs_set_linear_srgb(linearRGB);
 	}
 }
 


### PR DESCRIPTION
In OBS v27.x there is a new sRGB pipeline.

In order for textures not to appear burned out, we need to set sRGB off before copying the texture
and then revert afterwards

This relates to this commit https://github.com/obsproject/obs-studio/commit/66259560e03be5576bfad7f17aedc76a0b5a136d#diff-a42d3acdc6eea45c7cdaa3d028aa785a5481daf88bf777fe53e6cfcda81f3cf4R2020 in the underlying OBS source