### PR TITLE
Modified rendering to use target source size instead of parent source size to account for scaling applied by filters

### DIFF
--- a/source/win-spout-filter.cpp
+++ b/source/win-spout-filter.cpp
@@ -136,7 +136,11 @@ void win_spout_offscreen_render(void *data, uint32_t cx, uint32_t cy)
 	gs_texrender_t *texrender_prev = context->texrender_prev;
 	pthread_mutex_unlock(&context->mutex);
 
-	obs_source_t *target = obs_filter_get_parent(source_context);
+	obs_source_t *parent = obs_filter_get_parent(source_context);
+	if (!parent)
+		return;
+
+	obs_source_t *target = obs_filter_get_target(source_context);
 	if (!target)
 		return;
 
@@ -155,7 +159,7 @@ void win_spout_offscreen_render(void *data, uint32_t cx, uint32_t cy)
 		gs_blend_state_push();
 		gs_blend_function(GS_BLEND_ONE, GS_BLEND_ZERO);
 
-		obs_source_video_render(target);
+		obs_source_video_render(parent);
 
 		gs_blend_state_pop();
 		gs_texrender_end(texrender_intermediate);


### PR DESCRIPTION
New PR as accidentally pushed wrong `master` to https://github.com/Bemjo/obs-spout2-plugin which closed #67 

